### PR TITLE
Pass user into account_pending method

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -87,7 +87,7 @@ class RedmineOauthController < AccountController
       if user.active?
         successful_authentication(user)
       else
-        account_pending
+        account_pending(user)
       end
     end
   end


### PR DESCRIPTION
Fixes error during login into pending account:

    ArgumentError (wrong number of arguments (0 for 1)):
      app/controllers/account_controller.rb:337:in `account_pending'

---

Untested, but looks about right to me!