### PR TITLE
Add Redmine 3.x compat and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-## Redmine omniauth github
+## Redmine OmniAuth GitHub
 
 This plugin is used to authenticate in redmine through Github.
 It was more than inspired by redmine_omniauth_google see https://github.com/twinslash/redmine_omniauth_google
+
+### Compatibility
+
+It has been tested and/or should work with the following Redmine versions:
+
+* 3.x (tested on 3.1.x and 3.2.x)
 
 ### Installation:
 
@@ -20,7 +26,7 @@ To make possible to authenticate via Github you must first to register applicati
 * Go to the [registration](https://github.com/settings/applications/new) link.
 * When registering specify application name, for example, Redmine Oauth Githu.
 * Homepage URL is the url of your redmine installation
-* Callback URL is the same url with "/oauth2callback_github" appended, e.g. "http://example.net/oauth2callback_github"
+* Callback URL is the same url with "/oauth/github/callback" appended, e.g. "http://example.net/oauth/github/callback"
 * Press the button "Register application".
 
 The registrations is complete.

--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -15,10 +15,17 @@ class RedmineOauthController < AccountController
 
   def oauth_github_callback
     if params[:error]
-      flash[:error] = l(:notice_access_denied)
+      flash[:error] = l(:notice_github_access_denied)
       redirect_to signin_path
     else
-      token = oauth_client.auth_code.get_token(params[:code], :redirect_uri => oauth_github_callback_url)
+      token = nil
+      begin
+        token = oauth_client.auth_code.get_token(params[:code], :redirect_uri => oauth_github_callback_url)
+      rescue OAuth2::Error => e
+        flash[:error] = l(:notice_unable_to_obtain_github_credentials) + " " + e.description
+        redirect_to signin_path
+        return
+      end
       user = token.get('https://api.github.com/user')
       emails = token.get('https://api.github.com/user/emails',
                          :headers => {'Accept' => 'application/vnd.github.v3.full+json'})
@@ -29,11 +36,12 @@ class RedmineOauthController < AccountController
       unverified = emails.select { |e| !e['verified'] }.map { |v| v['email'] }
       primary = emails.select { |e| e['primary'] }.first.try(:[], 'email')
 
-      if (user = User.where(:mail => verified).first)
-        checked_try_to_login user.mail, user_info
+      if (user = User.find_by_mail(verified))
+        checked_try_to_login user.mail, user_info, user
       else
-        if User.where(:mail => unverified).blank? && verified.include?(primary)
-          checked_try_to_login primary, user_info
+        if User.find_by_mail(unverified).nil? && verified.include?(primary)
+          user = User.new
+          checked_try_to_login primary, user_info, user
         else
           flash[:error] = l(:notice_no_verified_email_we_could_use)
           redirect_to signin_path
@@ -42,52 +50,56 @@ class RedmineOauthController < AccountController
     end
   end
 
-  def checked_try_to_login(email, user)
+  def checked_try_to_login(email, info, user)
     if allowed_domain_for?(email)
-      try_to_login email, user
+      try_to_login email, info, user
     else
       flash[:error] = l(:notice_domain_not_allowed, :domain => parse_email(email)[:domain])
       redirect_to signin_path
     end
   end
 
-  def try_to_login email, info
-   params[:back_url] = session[:back_url]
-   session.delete(:back_url)
-   user = User.find_or_initialize_by_mail(email)
-    if user.new_record?
+  def try_to_login email, info, user
+    params[:back_url] = session[:back_url]
+    session.delete(:back_url)
+    @user = user
+    if @user.new_record?
       # Self-registration off
       redirect_to(home_url) && return unless Setting.self_registration?
       # Create on the fly
-      user.firstname, user.lastname = info["name"].split(' ') unless info['name'].nil?
-      user.firstname ||= info[:given_name]
-      user.lastname ||= info[:family_name]
-      user.mail = email
-      user.login = info['login']
-      user.login ||= [user.firstname, user.lastname]*"."
-      user.random_password
-      user.register
+      params = {}
+      params["firstname"], params["lastname"] = info["name"].split(' ') unless info['name'].nil?
+      params["firstname"] ||= info["login"]
+      params["lastname"] ||= 'please_edit_me'
+      params["mail"] = email
+
+      @user.login = info["login"]
+      @user.safe_attributes = params
+      @user.admin = false
+      @user.random_password
+      @user.register
 
       case Setting.self_registration
       when '1'
-        register_by_email_activation(user) do
-          onthefly_creation_failed(user)
+        register_by_email_activation(@user) do
+          onthefly_creation_failed(@user)
         end
       when '3'
-        register_automatically(user) do
-          onthefly_creation_failed(user)
+        register_automatically(@user) do
+          onthefly_creation_failed(@user)
         end
       else
-        register_manually_by_administrator(user) do
-          onthefly_creation_failed(user)
+        register_manually_by_administrator(@user) do
+          onthefly_creation_failed(@user)
         end
       end
     else
       # Existing record
-      if user.active?
-        successful_authentication(user)
+      if @user.active?
+        @user.update_column(:last_login_on, Time.now)
+        successful_authentication(@user)
       else
-        account_pending(user)
+        account_pending(@user)
       end
     end
   end

--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -36,7 +36,7 @@ class RedmineOauthController < AccountController
       unverified = emails.select { |e| !e['verified'] }.map { |v| v['email'] }
       primary = emails.select { |e| e['primary'] }.first.try(:[], 'email')
 
-      if (user = User.find_by_mail(verified))
+      if (user = User.where(:mail => verified).first)
         checked_try_to_login user.mail, user_info, user
       else
         if User.find_by_mail(unverified).nil? && verified.include?(primary)

--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -64,8 +64,14 @@ class RedmineOauthController < AccountController
     session.delete(:back_url)
     @user = user
     if @user.new_record?
+      # Retrieve self-registration setting
+      self_registration = settings[:github_self_registration]
+      if self_registration == '-1'
+        self_registration = Setting.self_registration || '0'
+      end
+
       # Self-registration off
-      redirect_to(home_url) && return unless Setting.self_registration?
+      redirect_to(home_url) && return unless self_registration != '0'
       # Create on the fly
       params = {}
       params["firstname"], params["lastname"] = info["name"].split(' ') unless info['name'].nil?
@@ -79,7 +85,7 @@ class RedmineOauthController < AccountController
       @user.random_password
       @user.register
 
-      case Setting.self_registration
+      case self_registration
       when '1'
         register_by_email_activation(@user) do
           onthefly_creation_failed(@user)

--- a/app/views/hooks/_view_account_login_bottom.html.erb
+++ b/app/views/hooks/_view_account_login_bottom.html.erb
@@ -1,10 +1,12 @@
 <%= stylesheet_link_tag 'buttons', :plugin => 'redmine_omniauth_github' %>
 
 <% if Setting.plugin_redmine_omniauth_github[:github_oauth_authentication] %>
-  <%= link_to oauth_github_path(:back_url => back_url) do %>
-    <%= button_tag :class => 'button-login' do %>
-      <%= image_tag('/plugin_assets/redmine_omniauth_github/images/github_login_icon.png', :class => 'button-login-icon', :alt => l(:login_via_github)) %>
-      <%= content_tag :div, l(:login_via_github), :class => 'button-login-text' %>
+  <div class="oauth-github-login">
+    <%= link_to oauth_github_path(:back_url => back_url) do %>
+      <%= button_tag :class => 'button-login' do %>
+        <%= image_tag('/plugin_assets/redmine_omniauth_github/images/github_login_icon.png') %>
+        <%= content_tag :span, l(:login_via_github) %>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/settings/_github_settings.html.erb
+++ b/app/views/settings/_github_settings.html.erb
@@ -1,16 +1,27 @@
 <p>
-  <label>Client ID:</label>
+  <%= content_tag(:label, l(:label_oauth_authentication)) %>
+  <%= check_box_tag "settings[github_oauth_authentication]", true, @settings[:github_oauth_authentication] %>
+</p>
+<p>
+  <%= content_tag(:label, l(:label_client_id)) %>
   <%= text_field_tag 'settings[client_id]', @settings[:client_id] %>
 </p>
 <p>
-  <label>Client Secret:</label>
+  <%= content_tag(:label, l(:label_client_secret)) %>
   <%= text_field_tag 'settings[client_secret]', @settings[:client_secret] %>
 </p>
 <p>
-  <label>Available domains</label>
-  <%= text_area_tag "settings[allowed_domains]", @settings[:allowed_domains], :rows => 5 %>
+  <%= content_tag(:label, l(:setting_self_registration)) %>
+  <%= select_tag 'settings[github_self_registration]',
+                  options_for_select([
+                      [l(:label_use_global_settings), "-1"],
+                      [l(:label_disabled), "0"],
+                      [l(:label_registration_activation_by_email), "1"],
+                      [l(:label_registration_manual_activation), "2"],
+                      [l(:label_registration_automatic_activation), "3"]
+                    ], @settings[:github_self_registration]) %>
 </p>
 <p>
-  <label>Oauth authentication:</label>
-  <%= check_box_tag "settings[github_oauth_authentication]", true, @settings[:github_oauth_authentication] %>
+  <%= content_tag(:label, l(:label_available_domains)) %>
+  <%= text_area_tag "settings[allowed_domains]", @settings[:allowed_domains], :rows => 5 %>
 </p>

--- a/assets/stylesheets/buttons.css
+++ b/assets/stylesheets/buttons.css
@@ -1,23 +1,14 @@
-.button-login {
-  position: relative;
-  left: 45%;
-  display: inline-block;
-  border: 1px solid #999;
-  border-radius: 2px;
-  margin-top: 10px;
-  width: 135px;
-  height: 25px;
-  padding: 0;
+.oauth-github-login {
+  display: block;
+  margin-top: 1em;
+  text-align: center;
 }
 
-.button-login-icon {
+.button-login > img {
   float: left;
   height: 18px;
-  padding: 1px 0px 0px 4px;
+  padding: 0 4px 0 0;
 }
-
-.button-login-text {
-  line-height: 21px;
-  background-image: -webkit-linear-gradient(bottom, #ddd, white);
-  font-size: 12px;
+.button-login > span {
+  line-height: 20px;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,8 @@ en:
   notice_github_access_denied: "You must allow to use you Github credentials to enter this site."
   login_via_github: "Login via Github"
   notice_no_verified_email_we_could_use: "No verified email provided by Github, go and verify you email address on github.com"
+  label_oauth_authentication: "OAuth authentication"
+  label_client_id: "Client ID"
+  label_client_secret: "Client Secret"
+  label_available_domains: "Available domains"
+  label_use_global_settings: "use global settings"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,9 @@
 en:
-  notice_unable_to_obtain_github_credentials: "Unable to obtain credentials from Github."
+  notice_unable_to_obtain_github_credentials: "Unable to obtain credentials from GitHub."
   notice_domain_not_allowed: "You can not login using %{domain} domain."
-  notice_github_access_denied: "You must allow to use you Github credentials to enter this site."
-  login_via_github: "Login via Github"
-  notice_no_verified_email_we_could_use: "No verified email provided by Github, go and verify you email address on github.com"
+  notice_github_access_denied: "You must allow to use you GitHub credentials to enter this site."
+  login_via_github: "Login via GitHub"
+  notice_no_verified_email_we_could_use: "No verified email provided by GitHub, go and verify you email address on github.com"
   label_oauth_authentication: "OAuth authentication"
   label_client_id: "Client ID"
   label_client_secret: "Client Secret"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,2 @@
-get 'oauth_github', :to => 'redmine_oauth#oauth_github'
-get 'oauth2callback_github', :to => 'redmine_oauth#oauth_github_callback', :as => 'oauth_github_callback'
+get 'oauth/github', :to => 'redmine_oauth#oauth_github'
+get 'oauth/github/callback', :to => 'redmine_oauth#oauth_github_callback', :as => 'oauth_github_callback'

--- a/init.rb
+++ b/init.rb
@@ -13,6 +13,7 @@ Redmine::Plugin.register :redmine_omniauth_github do
     :client_id => "",
     :client_secret => "",
     :github_oauth_autentication => false,
-    :allowed_domains => ""
+    :allowed_domains => "",
+    :github_self_registration => "-1"
   }, :partial => 'settings/github_settings'
 end


### PR DESCRIPTION
This is an unpretentious pull-request which mainly add Redmine 3.x compatibility - tested with 3.1.x and 3.2.x - based on https://github.com/ares/redmine_omniauth_github/commit/70ed29276262a7b0f60a01d17318dd3f62905b15. Please note that I didn't try if it's still compatible with older versions...

As other "improvements":
* the callback URLs have been changed from */oauth2callback_github* to */oauth/github/callback*
* a new self-registration setting has been added in order to manage how it is processed - e.g. by email, manual, automatic or as defined in global settings
* and small other "fixes" such as all strings translation and CSS normalization to try to fit with the global theme.