### PR TITLE
2 fixes for simple issues

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -4,6 +4,11 @@ require 'json'
 class RedmineOauthController < AccountController
   include Helpers::MailHelper
   include Helpers::Checker
+
+  def default_url_options(options={})
+    {:protocol => Setting[:protocol]}
+  end 
+
   def oauth_github
     if Setting.plugin_redmine_omniauth_github['github_oauth_authentication']
       session[:back_url] = params[:back_url]

--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -15,7 +15,7 @@ class RedmineOauthController < AccountController
 
   def oauth_github_callback
     if params[:error]
-      flash[:error] = l(:notice_github_access_denied)
+      flash[:error] = "Error: #{params[:error_description]} (#{params[:error]})"
       redirect_to signin_path
     else
       token = nil


### PR DESCRIPTION
1. When Github returns error regarding redirect_url not matching the configured one, the error message returned by plugin is misleading.
2. oauth_github_callback_url does not take into account the protocol used and creates HTTP link no matter what the Redmine protocol setting is.