### PR TITLE
Unverified email checking logic fix.

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -51,12 +51,12 @@ class RedmineOauthController < AccountController
         checked_try_to_login user.mail, user_info, user
       else
         if Redmine::VERSION.to_s.starts_with?('2.')
-          unverified_found = User.find_by_mail(unverified).nil? && verified.include?(primary)
+          unverified_found = User.find_by_mail(unverified)
         else
           unverified_found = User.joins(:email_addresses).where(:email_addresses => { :address => unverified }).first
         end
 
-        if unverified_found
+        if unverified_found.nil? && verified.include?(primary)
           user = User.new
           checked_try_to_login primary, user_info, user
         else


### PR DESCRIPTION
While searching for reason why new user cannot register when logging in with this plugin, I found that there was some logic error introduced in commit https://github.com/ares/redmine_omniauth_github/commit/7c44c8e8ec33c882634705c5dc87fe2e605185fe

In Redmine > 3 when unverified email from github was _not found_ in Redmine (or there was no unverified emails), plugin disallowed registration.